### PR TITLE
Sample of experimental specification for controllers: let them return Future's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ out
 packages
 packages/
 pubspec.lock
+.settings/com.google.dart.tools.core.prefs
+.settings/org.eclipse.ltk.core.refactoring.prefs

--- a/lib/src/server_impl.dart
+++ b/lib/src/server_impl.dart
@@ -101,7 +101,7 @@ class _StreamServer implements StreamServer {
     return uri;
   }
   ///[iFilter] - the index of filter to start. It must be non-negative. Ignored if null.
-  void _handle(HttpConnect connect, [int iFilter]) {
+  Future _handle(HttpConnect connect, [int iFilter]) {
     try {
       String uri = connect.request.uri.path;
       if (!uri.startsWith('/'))
@@ -121,8 +121,16 @@ class _StreamServer implements StreamServer {
       if (handler != null) {
         if (handler is Function)
           handler = handler(connect);
-        if (handler is String)
+        if (handler is String) {
           forward(connect, handler);
+        } else {
+          if( handler is Future<String> ) {
+            handler.then( (ret) {
+              // TODO: forward should be handled here
+            });
+          }
+          return handler;
+        }
         return;
       }
 
@@ -163,14 +171,16 @@ class _StreamServer implements StreamServer {
         return;
       }
 
+      /* this test matches, for example, uncatched errors when connecting to a DB
       if (error is SocketIOException) {
         //connection is closed. we can't close or forward it.
         logger.fine("${connect.request.uri}: $error");
         return;
       }
+      */
       if (error is! HttpStatusException) {
         _shout(error, stackTrace);
-        error = new Http500(error);
+        error = new Http500(error.toString());
       }
 
       final code = error.statusCode;
@@ -195,7 +205,7 @@ class _StreamServer implements StreamServer {
       forward(connect, handler);
   }
   void _shout(err, st) {
-    logger.shout(st != null ? "$err:\n$st": err);
+    logger.shout(st != null ? "$err:\n$st": err.toString());
   }
   void _close(HttpConnect connect) {
     connect.response.close();
@@ -294,11 +304,16 @@ class _StreamServer implements StreamServer {
       req.response.headers
         ..add(HttpHeaders.SERVER, serverInfo)
         ..date = new DateTime.now();
-      _handle(
-        new _HttpConnect(this, req, req.response)
-          ..onClose.listen((_) {
-            req.response.close();
-          }), 0); //process filter from beginning
+      var connect = new _HttpConnect(this, req, req.response);
+      new Future.of( () {
+        return _handle(
+          connect
+            ..onClose.listen((_) {
+              req.response.close();
+            }), 0); //process filter from beginning
+      }).catchError( (err) {
+        _handleErr(connect, err);
+      });
     }, onError: (err) {
       _handleErr(null, err);
     });


### PR DESCRIPTION
Hi developers:

This pull request is intended to show how it would be possible to allow controllers return Future's so that unhandled errors don't make the server crash. It's obviously not completely implemented (only one use case) as I haven't had time to look at all Stream's internals but you can get the feeling.

You can test it by writing a controller wich returns void and then throwing an error inside it. That will make the server return a 500 error instead of crashing.

Also, if you call async code inside the controller just throw an exception inside any then() block and you will get a 500 also. You can even chain some then()'s and don't write the catchError and it will still work as long as you return the last then's Future.

If you feel it makes sense please tell me and I will continue commiting changes until I refactor the whole thing. Or we can do it together, or you can do it alone. Whatever you prefer.

Regards,
Ivan
